### PR TITLE
Updated WORKER_AMI to reference current EKS-optimized AMI's

### DIFF
--- a/scripts/create_eks_cluster.sh
+++ b/scripts/create_eks_cluster.sh
@@ -60,7 +60,7 @@ if [ -z "${SPINNAKER_BUCKET}" ]; then
 fi
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-WORKER_AMI="ami-0a54c984b9f908c81"
+WORKER_AMI="ami-0e7ee8863c8536cce"
 WORKER_TYPE="t2.large"
 EKS_EC2_VPC_STACK_NAME="spin-eks-ec2-vpc"
 EKS_WORKER_STACK_NAME="spinnaker-infra-eks-nodes"


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
In February 2019 the EKS-optimized AMI's were updated and thus the WORKER_AMI was referencing an old AMI. I changed it to reflect the current AMI for us-west-2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
