### PR TITLE
upgrade eks-optimized ami id, kubectl, aws-iam-authenticator

### DIFF
--- a/buildspec-cleanup.yaml
+++ b/buildspec-cleanup.yaml
@@ -6,10 +6,10 @@ phases:
   build:
     commands:
       - apk add --no-cache curl bash
-      - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
+      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
       - chmod +x kubectl
       - mv kubectl /usr/local/bin
-      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
       - chmod +x aws-iam-authenticator
       - mv aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
       - ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)

--- a/buildspec-deploy.yaml
+++ b/buildspec-deploy.yaml
@@ -5,10 +5,10 @@ version: 0.2
 phases:
   build:
     commands:
-      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
+      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
       - chmod +x kubectl
       - mv kubectl /usr/local/bin
-      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
       - chmod +x aws-iam-authenticator
       - mv aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
       - curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"

--- a/buildspec-infra.yaml
+++ b/buildspec-infra.yaml
@@ -6,10 +6,10 @@ phases:
   build:
     commands:
       - apk add --no-cache curl bash
-      - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
+      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
       - chmod +x kubectl
       - mv kubectl /usr/local/bin
-      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+      - curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator
       - chmod +x aws-iam-authenticator
       - mv aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
       - ./scripts/create_eks_cluster.sh -k ${K8S_NAME} -s ${K8S_KEYPAIR} -b ${BUCKET_NAME}

--- a/resources/cloudformation/codebuild-projects.yaml
+++ b/resources/cloudformation/codebuild-projects.yaml
@@ -128,7 +128,7 @@ Resources:
           -
             Name: SPINNAKER_VERSION
             Type: PLAINTEXT
-            Value: 1.10.2
+            Value: 1.16.4
       Name: deploy-spinnaker
       ServiceRole: !Ref CreateEKSSpinnakerRole
       Source:

--- a/scripts/create_eks_cluster.sh
+++ b/scripts/create_eks_cluster.sh
@@ -60,7 +60,7 @@ if [ -z "${SPINNAKER_BUCKET}" ]; then
 fi
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-WORKER_AMI="ami-0e7ee8863c8536cce"
+WORKER_AMI="ami-05d586e6f773f6abf"
 WORKER_TYPE="t2.large"
 EKS_EC2_VPC_STACK_NAME="spin-eks-ec2-vpc"
 EKS_WORKER_STACK_NAME="spinnaker-infra-eks-nodes"


### PR DESCRIPTION
Upgrade eks-optimized ami id, kubectl, and aws-iam-authenticator for Kubernetes 1.14.

Upgrade Spinnaker version to latest. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
